### PR TITLE
Add Image3D to 3D tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ AWS|[Titan](https://aws.amazon.com/bedrock/amazon-models/titan/)|[Nova](https://
 - [backflip](https://www.backflip.ai/) - AI 3D design tools for the physical world
 - [cadwithai](https://www.cadwithai.com/) - a tool that allows users to create and edit CAD models using an AI chatbot to enhance efficiency and creativity in design work
 - [Meshy](https://www.meshy.ai/) - create stunning 3D models with AI
+- [Image3D](https://image3d.io/) - generate 3D assets from images with GLB, OBJ, STL, and PLY exports
 - [Generative 3D API Toolkit](https://www.shutterstock.com/discover/generative-ai-3d) - generate 3D models, materials, and HDRIs at the speed of your imagination. Supercharge your 3D workflow with our groundbreaking Gen3D toolkit from Shutterstock powered by NVIDIA
 - [Seele AI](https://www.seeles.ai/) - input text to generate playable 3D Games and Asserts
 - [Stable Fast 3D](https://stability.ai/news/introducing-stable-fast-3d) - generates high-quality 3D assets from a single image, by Stability AI


### PR DESCRIPTION
Adds Image3D to the 3D tools section.

Image3D fits this section as an image-to-3D generator with GLB, OBJ, STL, and PLY exports.