### PR TITLE
Add SenseBench to Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ AWS|[Titan](https://aws.amazon.com/bedrock/amazon-models/titan/)|[Nova](https://
 - [Game Arena](https://www.kaggle.com/game-arena) - a new benchmarking platform where AI models and agents compete head-to-head in a variety of strategic games to help chart new frontiers for trustworthy AI evaluation, by Kaggle
 - [OpenRouter](https://openrouter.ai/rankings) - a unified interface for LLMs
 - [MathArena](https://matharena.ai/) - a platform for evaluation of LLMs on the latest math competitions and olympiads
+- [SenseBench](https://sense-bench.com) - a leaderboard for English word sense disambiguation: models pick the correct WordNet sense for a word in context, scored on a lexicographer-reviewed 4,861-item dataset with every run re-verified from stored raw API responses, by Glite
 - [EU AI Act Compliance Leaderboard](https://huggingface.co/spaces/latticeflow/compl-ai-board) - the high-level regulatory requirements of the EU AI Act as concrete technical requirements
 - [AgentBoard](https://hkust-nlp.github.io/agentboard/) - a benchmark designed for multi-turn LLM agents, complemented by an analytical evaluation board for detailed model assessment beyond final success rates
 - [LLM Hallucination Index](https://www.rungalileo.io/hallucinationindex) - A Ranking & Evaluation Framework For LLM Hallucinations


### PR DESCRIPTION
Adds one line to **Large Language Models (LLMs) and Chatbots → Leaderboards**, after MathArena.

```markdown
- [SenseBench](https://sense-bench.com) - a leaderboard for English word sense disambiguation: models pick the correct WordNet sense for a word in context, scored on a lexicographer-reviewed 4,861-item dataset with every run re-verified from stored raw API responses, by Glite
```

The section covers general capability, math, code, safety, hallucination and agents, but nothing lexical. SenseBench fills that: each model is shown a target word in its sentence context together with the candidate WordNet 3.0 senses and must return the index of the correct one. 198 verified runs across 63 models so far, alongside classic supervised WSD systems (MFS, BEM, ESCHER, ConSeC) scored on identical items for reference.

Two things that may be of interest given what else is listed here:

* Submissions are re-verified in CI from the stored raw API request/response artifacts rather than trusted from reported metadata, and results carry bootstrap confidence intervals and paired McNemar comparisons.
* Cost per million items is reported for both API and self-hosted runs, the latter priced at fixed reference GPU rates so runs stay comparable across rentals.

Results are also available as JSON at `https://sense-bench.com/data/leaderboard.json`. Only `README.md` is touched, matching the recent merged PRs.