### PR TITLE
Add Luphra to 3D tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ AWS|[Titan](https://aws.amazon.com/bedrock/amazon-models/titan/)|[Nova](https://
 - [backflip](https://www.backflip.ai/) - AI 3D design tools for the physical world
 - [cadwithai](https://www.cadwithai.com/) - a tool that allows users to create and edit CAD models using an AI chatbot to enhance efficiency and creativity in design work
 - [Meshy](https://www.meshy.ai/) - create stunning 3D models with AI
+- [Luphra](https://www.luphra.com/) - prompt-to-matter: text/sketch to editable 3D and manufactured physical products
 - [Image3D](https://image3d.io/) - generate 3D assets from images with GLB, OBJ, STL, and PLY exports
 - [Generative 3D API Toolkit](https://www.shutterstock.com/discover/generative-ai-3d) - generate 3D models, materials, and HDRIs at the speed of your imagination. Supercharge your 3D workflow with our groundbreaking Gen3D toolkit from Shutterstock powered by NVIDIA
 - [Seele AI](https://www.seeles.ai/) - input text to generate playable 3D Games and Asserts


### PR DESCRIPTION
Add Luphra (https://www.luphra.com/) under ## 3D after Meshy.

Prompt-to-matter: text/sketch to editable 3D and manufactured physical products. Fits the existing Meshy / backflip / Image3D / Spline / Luma Genie cluster.
