### PR TITLE
Add YYLO to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ AWS|[Titan](https://aws.amazon.com/bedrock/amazon-models/titan/)|[Nova](https://
 - [JARVIS-1](https://craftjarvis-jarvis1.github.io/) - Open-world Multi-task Agents with Memory-Augmented Multimodal Language Models, generate sophisticated plans, and perform embodied control, within the open-world Minecraft universe
 - [AppAgent](https://github.com/mnotgod96/AppAgent) - Multimodal Agents as Smartphone Users, an LLM-based multimodal agent framework designed to operate smartphone app
 - [Kiln AI](https://kiln.tech) - a free desktop app that provides tools for building AI products such as evals, RAG systems, agents, fine-tuning, synthetic data, and more, all without coding
+- [YYLO](https://github.com/yylo-dev/yylo) - an open-source command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries, a dedicated branch/worktree per task, and a risk-based merge queue; installable via npm
 
 ## Code & Math
 ||Code|Math|


### PR DESCRIPTION
## Summary

Adds **YYLO** to the Agents section.

YYLO is an open-source command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries, a dedicated branch/worktree per task, and a risk-based merge queue. It runs multi-agent development loops (Pi and Codex subagents are supported today) from one typed CLI (`yylo`/`yy`), installable via npm as `@yylo/cli`.

## Fit

This repository's Agents section lists multi-agent orchestration frameworks and coding-agent platforms (Multi-Agent Orchestrator, swarm, OpenHands, BeeAI Framework). YYLO is the terminal-first counterpart: it orchestrates coding agents across dedicated git worktrees and owns the task/merge lifecycle around them. The entry follows the section's one-line link-and-description format and points to the official source.

## Validation

- Searched the README, repository history, pull requests, and issues for duplicates — no existing YYLO entry.
- Verified the repository link returns HTTP 200; MIT license is API-detectable; the repo is under active daily development (58 stars).
- Confirmed recent accepted pull requests (#20 StructEval, #18 Illustro) edit `README.md` directly with a single one-line entry; this PR matches that shape (+1/−0).
- Ran `git diff --check`.

## Disclosure

I'm part of the YYLO team and prepared this submission with an AI coding agent, following the house format of recently merged entries. Happy to adjust the description or section if you prefer a different placement — thank you for maintaining this list!
